### PR TITLE
Add Debian and Fedora to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 This bug was fix in https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3b0462726e7ef281c35a7a4ae33e93ee2bc9975b
 
-This exploit works on most Centos 8 kernels higher than linux-4.18.0-305.el8 and most ubuntu 18/20 kernels higher than 5.4.0-84 and 5.11.0-37.41.
+This exploit works on most pre-patch kernels for:
 
-Please feel free to send a PR to update README if you find it could work on other kernel.
+* CentOS 8 kernels higher than linux-4.18.0-305.el8
+* Debian 11 kernels higher than 5.10.0-8
+* Fedora 31/32/33 kernels higher than 5.3.7-301.fc31
+* Ubuntu 18/20 kernels higher than 5.4.0-84 and 5.11.0-37.41
 
-
+Please feel free to send a PR to update README if you find it could work on other kernels.


### PR DESCRIPTION
Tested on:

* Debian 11 kernel 5.10.0-8-amd64
* Fedora 31 kernel 5.3.7-301.fc31.x86_64
* Fedora 33 kernel 5.8.15-301.fc33.x86_64

These are the default kernels for each distro.
